### PR TITLE
Improvement: Rename preprocessor

### DIFF
--- a/src/MbedHardwareSPI.cpp
+++ b/src/MbedHardwareSPI.cpp
@@ -1,4 +1,4 @@
-#if defined(__arm__) && defined(MBED_SB)
+#if defined(__arm__) && defined(MBED)
 
 #include "MbedHardwareSPI.h"
 

--- a/src/MbedHardwareSPI.h
+++ b/src/MbedHardwareSPI.h
@@ -1,4 +1,4 @@
-#if defined(__arm__) && defined(MBED_SB)
+#if defined(__arm__) && defined(MBED)
 
 #ifndef _MBED_HARDWARE_SPI_H_
 #define _MBED_HARDWARE_SPI_H_


### PR DESCRIPTION
The preprocessor for MBED "MBED_SB" is not suitable. So use "MBED" instead